### PR TITLE
Fix binary permissions in Dockerfiles

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,9 +14,8 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
-WORKDIR /root/
-COPY --from=builder /app/main .
-RUN chown appuser:appgroup main
+WORKDIR /app
+COPY --from=builder --chown=appuser:appgroup /app/main .
 USER appuser
 EXPOSE 8080
 CMD ["./main"]

--- a/message-service/Dockerfile
+++ b/message-service/Dockerfile
@@ -14,9 +14,8 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
-WORKDIR /root/
-COPY --from=builder /app/main .
-RUN chown appuser:appgroup main
+WORKDIR /app
+COPY --from=builder --chown=appuser:appgroup /app/main .
 USER appuser
 EXPOSE 8080
 CMD ["./main"]

--- a/time-service/Dockerfile
+++ b/time-service/Dockerfile
@@ -14,9 +14,8 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
-WORKDIR /root/
-COPY --from=builder /app/main .
-RUN chown appuser:appgroup main
+WORKDIR /app
+COPY --from=builder --chown=appuser:appgroup /app/main .
 USER appuser
 EXPOSE 8080
 CMD ["./main"]

--- a/weather-service/Dockerfile
+++ b/weather-service/Dockerfile
@@ -14,9 +14,8 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
-WORKDIR /root/
-COPY --from=builder /app/main .
-RUN chown appuser:appgroup main
+WORKDIR /app
+COPY --from=builder --chown=appuser:appgroup /app/main .
 USER appuser
 EXPOSE 8080
 CMD ["./main"]


### PR DESCRIPTION
When I tried to run `ocuroot release new network/package.ocu.star --cascade` as described in the getting started guide on OSX, I got this error:

```
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./main": stat ./main: permission denied: unknown.
ERRO[0000] error waiting for container: context canceled
```

This change makes the image build for me.